### PR TITLE
Add proxy configuration options

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,15 @@
+# Example configuration file for BOLTCipherVerifier
+# Copy to .env and adjust values as needed
+
+# Host and port configuration
+APP_HOST=127.0.0.1
+APP_PORT=8000
+
+# Optional root path if the app is mounted under a sub-path
+FASTAPI_ROOT_PATH=
+
+# Enable if running behind a reverse proxy
+PROXY_HEADERS=True
+# Comma separated list of trusted proxy IPs ('*' to trust any)
+FORWARDED_ALLOW_IPS=*
+

--- a/README.md
+++ b/README.md
@@ -71,3 +71,17 @@ podman run --rm -p 8000:8000 boltcipherverifier
 ```
 
 The application will be available at `http://localhost:8000`.
+
+## Configuration via Environment Variables
+
+The application can be configured through environment variables. You can copy
+`.env-example` to `.env` and adjust the values or set them directly in your
+environment.
+
+- `APP_HOST` - Host address to bind (default `127.0.0.1`).
+- `APP_PORT` - Port to listen on (default `8000`).
+- `FASTAPI_ROOT_PATH` - Root path when the app is served behind a proxy.
+- `PROXY_HEADERS` - Set to `True` if the app is running behind a reverse proxy.
+- `FORWARDED_ALLOW_IPS` - Comma separated list of trusted proxy IPs (`*` to trust any).
+
+

--- a/main.py
+++ b/main.py
@@ -121,4 +121,14 @@ if __name__ == "__main__":
     app_host = os.getenv("APP_HOST", "127.0.0.1")
     app_port = int(os.getenv("APP_PORT", "8000"))
 
-    uvicorn.run(app, host=app_host, port=app_port)
+    proxy_headers_env = os.getenv("PROXY_HEADERS", "False")
+    proxy_headers = proxy_headers_env.lower() in ("1", "true", "yes", "on")
+    forwarded_allow_ips = os.getenv("FORWARDED_ALLOW_IPS", "127.0.0.1")
+
+    uvicorn.run(
+        app,
+        host=app_host,
+        port=app_port,
+        proxy_headers=proxy_headers,
+        forwarded_allow_ips=forwarded_allow_ips,
+    )


### PR DESCRIPTION
## Summary
- add ability to configure `proxy_headers` and `forwarded_allow_ips`
- include new settings in `.env-example`
- document all environment variables in the README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687b562a8df88333806c6f9793dd104d